### PR TITLE
chore: use single quotes in import statements for consistency

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -31,7 +31,7 @@ const Page = () => {
           <pre>
             <code>
               {`import { getPayload } from 'payload'
-import configPromise from "@payload-config";
+import configPromise from '@payload-config'
 const payload = await getPayload({ config: configPromise })
 
 const data = await payload.find({


### PR DESCRIPTION
Just a small change to the example on the front page to make import statements consistent with the rest.