### PR TITLE
fix: 'json' does not exist on type

### DIFF
--- a/src/app/my-route/route.ts
+++ b/src/app/my-route/route.ts
@@ -1,5 +1,6 @@
-import { getPayload } from 'payload'
 import configPromise from '@payload-config'
+import { NextResponse } from 'next/server'
+import { getPayload } from 'payload'
 
 export const GET = async () => {
   const payload = await getPayload({
@@ -10,5 +11,5 @@ export const GET = async () => {
     collection: 'users',
   })
 
-  return Response.json(data)
+  return NextResponse.json(data)
 }


### PR DESCRIPTION
Property 'json' does not exist on type '{ new (body?: BodyInit | null | undefined, init?: ResponseInit | undefined): Response; prototype: Response; error(): Response; redirect(url: string | URL, status?: number | undefined): Response; }'

<img width="719" alt="Screenshot 2024-04-26 at 1 33 51 AM" src="https://github.com/payloadcms/payload-3.0-demo/assets/88515844/f23066e5-d1e9-47a4-9c36-ba81ef2e6be8">

Solution:
<img width="712" alt="Screenshot 2024-04-26 at 1 35 00 AM" src="https://github.com/payloadcms/payload-3.0-demo/assets/88515844/2a921a4d-eb56-47d0-bac3-47bb19743245">
