### PR TITLE
chore: bumps next canary version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@payloadcms/ui": "3.0.0-beta.22",
     "cross-env": "^7.0.3",
     "graphql": "^16.8.1",
-    "next": "14.3.0-canary.28",
+    "next": "14.3.0-canary.37",
     "payload": "3.0.0-beta.22",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Closes #172 

Next version 14.3.0-canary.28 was causing a TypeError when creating a new doc, issue is resolved in latest canary version.