### PR TITLE
docs: fix env file name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To try out this repo yourself, follow the steps below:
 
 1. Clone the repo to your computer (`git clone git@github.com:payloadcms/payload-3.0-demo.git`)
 2. `cd` into the new folder by running `cd ./payload-3.0-demo`
-3. Copy the `.env.local.example` by running `cp .env.local.example .env.example` in the repo, then fill out the values including the connection string to your DB
+3. Copy the `.env.local.example` by running `cp .env.local.example .env.local` in the repo, then fill out the values including the connection string to your DB
 4. Install dependencies with whatever package manager you use (`pnpm o`, `npm install`, `yarn`, etc.). `pnpm` is highly recommended. The usage of yarn v1 is discouraged.
 5. Start your database. For local postgresql use `.\start-database.sh` to start it in docker container.
 6. Fire it up (`pnpm dev`, `npm run dev`, `yarn dev`, etc.)


### PR DESCRIPTION
Environment variables must be in an `.env.local` file (and not `.env.example`)

See https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables