### PR TITLE
fix: use Mongo everywhere (sync start-database script with Payload config)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To try out this repo yourself, follow the steps below:
 2. `cd` into the new folder by running `cd ./payload-3.0-demo`
 3. Copy the `.env.local.example` by running `cp .env.local.example .env.example` in the repo, then fill out the values including the connection string to your DB
 4. Install dependencies with whatever package manager you use (`pnpm o`, `npm install`, `yarn`, etc.). `pnpm` is highly recommended. The usage of yarn v1 is discouraged.
-5. Start your database. For local postgresql use `.\start-database.sh` to start it in docker container.
+5. Start your database. For local mongo use `.\start-database.sh` to start it in docker container.
 6. Fire it up (`pnpm dev`, `npm run dev`, `yarn dev`, etc.)
 7. Visit https://localhost:3000 and log in with the user created within the config's `onInit` method
 

--- a/start-database.sh
+++ b/start-database.sh
@@ -22,7 +22,7 @@ if [ "$DB_PASSWORD" = "password" ]; then
   echo "You are using the default database password"
 fi
 
-docker run --name $DB_CONTAINER_NAME -e POSTGRES_PASSWORD=$DB_PASSWORD -e POSTGRES_HOST_AUTH_METHOD=trust -e POSTGRES_DB=next-payload-3 -d -p 5432:5432 docker.io/postgres
+docker run --name $DB_CONTAINER_NAME -d -p 27017:27017 docker.io/mongo
 
 echo "Database container was successfully created"
 


### PR DESCRIPTION
The `payload.config.ts` uses Mongo by default, but the `start-database.sh` starts a PostgreSQL instance. This sets MongoDB everywhere.