### PR TITLE
Update readme file to fix typo for repo instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ We are making this available to our community so that we can gather your feedbac
 ### Existing Next.js project
 
 You can install Payload into your existing Next.js project using this command:
+
 ```
 npx create-payload-app@beta
 ```
+
 Contents from `src/app` will have to be moved into a new directory `src/app/(app)` so that Payload's root layout and routes can remain isolated from the rest of your app.
 
 ### Using this repo
@@ -53,7 +55,7 @@ To try out this repo yourself, follow the steps below:
 1. Clone the repo to your computer (`git clone git@github.com:payloadcms/payload-3.0-demo.git`)
 2. `cd` into the new folder by running `cd ./payload-3.0-demo`
 3. Copy the `.env.local.example` by running `cp .env.local.example .env.local` in the repo, then fill out the values including the connection string to your DB
-4. Install dependencies with whatever package manager you use (`pnpm o`, `npm install`, `yarn`, etc.). `pnpm` is highly recommended. The usage of yarn v1 is discouraged.
+4. Install dependencies with whatever package manager you use (`pnpm i`, `npm install`, `yarn`, etc.). `pnpm` is highly recommended. The usage of yarn v1 is discouraged.
 5. Start your database. For local postgresql use `.\start-database.sh` to start it in docker container.
 6. Fire it up (`pnpm dev`, `npm run dev`, `yarn dev`, etc.)
 7. Visit https://localhost:3000 and log in with the user created within the config's `onInit` method


### PR DESCRIPTION
This is a quick PR to fix what appears to be a typo `pnpm o`, expecting `pnpm i` in the readme file for project setup. 