### PR TITLE
Fix Discord Link

### DIFF
--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -17,7 +17,7 @@ const Page = () => {
             </Link>{' '}
             or in the{' '}
             <Link
-              href="https://discord.com/channels/967097582721572934/1215659716538273832"
+              href="https://discord.gg/damphACG"
               target="_blank"
             >
               dedicated channel in Discord


### PR DESCRIPTION
The current discord is a link to the channel. If you're not in the discord the link won't load. This updates the link to the Payload discord (specifically the ``#payload-3_0-feedback`` channel)